### PR TITLE
Fix the location of the C extension

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, Extension
 import numpy as np
 from Cython.Build import cythonize
 
-fastss_ext = Extension("*",
+fastss_ext = Extension("Ska.Numpy.fastss",
                        ['Ska/Numpy/fastss.pyx'],
                        include_dirs=[np.get_include()])
 try:


### PR DESCRIPTION
## Description

After the namespace module changes, it turned out the fastss C extension was being installed in site-packages/numpy instead of site-packages/Ska/Numpy. This PR fixes that.

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)
- [ ] Functional testing (no functional tests were made)

Fixes #