### PR TITLE
Allow setup.py --version to run without Cython, numpy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,16 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from setuptools import setup, Extension
 
-import numpy as np
-from Cython.Build import cythonize
+try:
+    from Cython.Build import cythonize
+    import numpy as np
+    fastss_ext = Extension("Ska.Numpy.fastss",
+                           ['Ska/Numpy/fastss.pyx'],
+                           include_dirs=[np.get_include()])
+except ImportError:
+    cythonize = lambda arg: None
+    fastss_ext = None
 
-fastss_ext = Extension("Ska.Numpy.fastss",
-                       ['Ska/Numpy/fastss.pyx'],
-                       include_dirs=[np.get_include()])
 try:
     from testr.setup_helper import cmdclass
 except ImportError:

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,18 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import sys
 from setuptools import setup, Extension
 
-try:
+# Special case here to allow `python setup.py --version` to run without
+# requiring cython and numpy to be installed.
+if '--version' in sys.argv[1:]:
+    cythonize = lambda arg: None
+    fastss_ext = None
+else:
     from Cython.Build import cythonize
     import numpy as np
     fastss_ext = Extension("Ska.Numpy.fastss",
                            ['Ska/Numpy/fastss.pyx'],
                            include_dirs=[np.get_include()])
-except ImportError:
-    cythonize = lambda arg: None
-    fastss_ext = None
 
 try:
     from testr.setup_helper import cmdclass


### PR DESCRIPTION
## Description

This addresses the problem in https://github.com/sot/skare3/issues/255.

See https://github.com/sot/Chandra.Time/pull/40 for more details of functional testing (environment setup and commands).

## Testing

- [x] Passes unit tests on MacOS
- [x] Functional testing
  - `setup.py --version` gives expected output in a minimal env (no Cython, no numpy)
  - `setup.py build_ext --inplace` fails in the minimal env with an import error
  - `setup.py test` builds and passes in a ska3 env
