### PR TITLE
Version for shiny

### DIFF
--- a/Ska/Numpy/__init__.py
+++ b/Ska/Numpy/__init__.py
@@ -3,7 +3,7 @@ import ska_helpers
 
 from .Numpy import *
 
-__version__ = ska_helpers.get_version(__package__)
+__version__ = ska_helpers.get_version('Ska.Numpy')
 
 
 def test(*args, **kwargs):

--- a/Ska/Numpy/tests/test_numpy.py
+++ b/Ska/Numpy/tests/test_numpy.py
@@ -44,8 +44,8 @@ def test_structured_array():
 
 
 def test_search_both_sorted():
-    a = np.linspace(1, 10, 1e6)
-    v = np.linspace(0, 11, 1e6)
+    a = np.linspace(1, 10, 1_000_000)
+    v = np.linspace(0, 11, 1_000_000)
     i_np = np.searchsorted(a, v)
     i_sbs = Ska.Numpy.search_both_sorted(a, v)
     assert np.all(i_np == i_sbs)
@@ -56,8 +56,8 @@ def test_search_both_sorted():
     i_sbs = Ska.Numpy.search_both_sorted(a, v)
     assert np.all(i_np == i_sbs)
 
-    a = np.linspace(1, 10, 1e6)
-    v = np.linspace(0, 11, 1e2)
+    a = np.linspace(1, 10, 1_000_000)
+    v = np.linspace(0, 11, 100)
     i_np = np.searchsorted(a, v)
     i_sbs = Ska.Numpy.search_both_sorted(a, v)
     assert np.all(i_np == i_sbs)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+filterwarnings =
+    ignore:the imp module:DeprecationWarning


### PR DESCRIPTION
## Description

Make pytest no longer fail because of issues with ska_helpers and version.

Also fixes a test error that appears using recent numpy, and adds `pytest.init` to suppress warnings like below. These occur in upstream packages and there is nothing to do but ignore.
```
  /Users/aldcroft/miniconda3/envs/ska3-shiny/lib/python3.6/site-packages/nose/importer.py:12: 
DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's
documentation for alternative uses
   from imp import find_module, load_module, acquire_lock, release_lock
```

## Testing

- [x] Passes unit tests on MacOS ska3-shiny
- [x] Passes unit tests on MacOS ska3 (flight)
