### PR TITLE
Fix issue importing Ska.Numpy

### DIFF
--- a/ska_numpy/Numpy.py
+++ b/ska_numpy/Numpy.py
@@ -7,10 +7,7 @@ import numpy as np
 import re
 import operator
 import sys
-try:
-    from . import fastss
-except ImportError:
-    pass
+from ska_numpy import fastss
 
 __docformat__ = "restructuredtext en"
 


### PR DESCRIPTION
## Description

This makes the `ska_numpy` and `Ska.Numpy` packages both correctly find the `fastss` compiled Cython module. The current `setup.py` only installs this compiled module to `ska_numpy.fastss`.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by Javier
- [x] Linux

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Clean out any existing package files:
```
$ rm -rf /Users/aldcroft/miniconda3/envs/ska3-flight-2023.1rc4/lib/python3.10/site-packages/Ska/Numpy
$ rm -rf /Users/aldcroft/miniconda3/envs/ska3-flight-2023.1rc4/lib/python3.10/site-packages/ska_numpy
```

Install and test:

```
(ska3-flight-2023.1rc4) ➜  Ska.Numpy git:(master) ✗ python setup.py install --single-version-externally-managed --record=record.txt 
(ska3-flight-2023.1rc4) ➜  Ska.Numpy git:(master) ✗ cd docs 
(ska3-flight-2023.1rc4) ➜  docs git:(master) ✗ ipython
Python 3.10.8 | packaged by conda-forge | (main, Nov 22 2022, 08:27:35) [Clang 14.0.6 ]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.8.0 -- An enhanced Interactive Python. Type '?' for help.
im
In [1]: import Ska.Numpy

In [2]: Ska.Numpy.test()
=================================================================== test session starts ===================================================================
platform darwin -- Python 3.10.8, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/aldcroft/miniconda3/envs/ska3-flight-2023.1rc4/lib/python3.10/site-packages
plugins: anyio-3.6.2
collected 6 items                                                                                                                                         

Ska/Numpy/tests/test_numpy.py ......                                                                                                                [100%]

==================================================================== 6 passed in 0.10s ====================================================================
Out[2]: False

In [3]: Ska.Numpy.__file__
Out[3]: '/Users/aldcroft/miniconda3/envs/ska3-flight-2023.1rc4/lib/python3.10/site-packages/Ska/Numpy/__init__.py'

In [4]: Ska.Numpy.__version__
Out[4]: '4.0.1.dev0+g9f4adaf.d20230208'

In [5]: ls /Users/aldcroft/miniconda3/envs/ska3-flight-2023.1rc4/lib/python3.10/site-packages/Ska/Numpy
Numpy.py     __init__.py  __pycache__/ tests/

In [6]: import ska_numpy

In [7]: ska_numpy.__version__
Out[7]: '4.0.1.dev0+g9f4adaf.d20230208'

In [8]: ska_numpy.__file__
Out[8]: '/Users/aldcroft/miniconda3/envs/ska3-flight-2023.1rc4/lib/python3.10/site-packages/ska_numpy/__init__.py'

In [9]: ska_numpy.test()
=================================================================== test session starts ===================================================================
platform darwin -- Python 3.10.8, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/aldcroft/miniconda3/envs/ska3-flight-2023.1rc4/lib/python3.10/site-packages
plugins: anyio-3.6.2
collected 6 items                                                                                                                                         

ska_numpy/tests/test_numpy.py ......                                                                                                                [100%]

==================================================================== 6 passed in 0.08s ====================================================================
Out[9]: False
```

