### PR TITLE
Replace use of int_t with int64_t

### DIFF
--- a/ska_numpy/fastss.pyx
+++ b/ska_numpy/fastss.pyx
@@ -4,7 +4,7 @@ cimport numpy as np
 
 DTYPE = int
 
-ctypedef np.int_t DTYPE_t
+ctypedef np.int64_t DTYPE_t
 ctypedef np.double_t DTYPE_double_t
 
 @cython.wraparound(False)


### PR DESCRIPTION
## Description

I had to make this small change to build the package for numpy 2.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3-flight-2026.0rc2) ~/miniforge3/envs/ska3-flight-2026.0rc2/lib/python3.13/site-packages $ pytest ska_numpy
==================================================================== test session starts =====================================================================
platform darwin -- Python 3.13.9, pytest-9.0.1, pluggy-1.6.0
rootdir: /Users/javierg/miniforge3/envs/ska3-flight-2026.0rc2/lib/python3.13/site-packages
plugins: anyio-4.12.0, timeout-2.4.0
collected 6 items                                                                                                                                            

ska_numpy/tests/test_numpy.py ......                                                                                                                   [100%]

===================================================================== 6 passed in 0.17s ======================================================================
(ska3-flight-2026.0rc2) ~/miniforge3/envs/ska3-flight-2026.0rc2/lib/python3.13/site-packages $ python -c "import ska_numpy; print(ska_numpy.__version__)"
4.0.2.dev0+gbd7c345.d20251202
```

Independent check of unit tests by Jean
- [x] OSX with latest and hope
```
(ska3-flight-2026.0rc3) flame:ska_numpy jean$ git rev-parse HEAD
861e9e27987eed9b8df7379719c3913fb3838ee9
(latest) flame:ska_numpy jean$ pytest
=============================================== test session starts ================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/jean/git/ska_numpy
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 6 items                                                                                                  

ska_numpy/tests/test_numpy.py ......                                                                         [100%]

================================================ 6 passed in 0.28s

(ska3-flight-2026.0rc3) flame:ska_numpy jean$ pytest
================================================================== test session starts ===================================================================
platform darwin -- Python 3.13.9, pytest-9.0.1, pluggy-1.6.0
rootdir: /Users/jean/git/ska_numpy
configfile: pytest.ini
plugins: anyio-4.12.0, timeout-2.4.0
collected 6 items                                                                                                                                        

ska_numpy/tests/test_numpy.py ......                                                                                                               [100%]

=================================================================== 6 passed in 0.63
```
In both cases I just build locally with `python setup.py build_ext --inplace` to run the tests

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->

I ran a simple check, just to make sure, although I suspect this is covered by the tests:
```
from scipy.interpolate import interp1d
import ska_numpy
x = np.linspace(0, 1, 20)
y = np.cos(x*np.pi)
f = interp1d(x, y)
x2 = np.linspace(0.1, 0.9, 8)
y2 = f(x2)
y3 = ska_numpy.interpolate(y, x, x2)
np.all(y2 == y3)
```
